### PR TITLE
chore(.gitignore): remove debug.sh from the list of ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ instance/*
 !instance/.gitignore
 .webassets-cache
 .env
-debug.sh
 
 ### Flask.Python Stack ###
 # Byte-compiled / optimized / DLL files


### PR DESCRIPTION
The debug.sh file is to be added to the git repository and has been removed from the list of ignored files in the .gitignore file.