### PR TITLE
chore(debug.sh): add debug.sh script to run Flask app in debug mode

### DIFF
--- a/debug.sh
+++ b/debug.sh
@@ -1,0 +1,1 @@
+flask --app app/main.py --debug run --host 127.0.0.1


### PR DESCRIPTION
The debug.sh script is added to the repository. This script allows running the Flask app in debug mode with the specified host (127.0.0.1). This script can be used for local development and debugging purposes.
