### PR TITLE
fix(main.py): remove trailing comma in import statement to fix syntx error

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, render_template,
+from flask import Flask, request, render_template
 from markupsafe import escape
 import os
 


### PR DESCRIPTION
The trailing comma in the import statement has been removed to fix a syntax error.
