### PR TITLE
Fix Dockerfile and updated docker-compose.* and CONTRIBUTING.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,28 @@
 # Use the official Python image from the Docker Hub
 FROM python:3.12-slim
 
-# Expose the port the app runs on
-EXPOSE 5000
-
-# Keeps Python from generating .pyc files in the container
-ENV PYTHONDONTWRITEBYTECODE=1
-
-# Turns off buffering for easier container logging
-ENV PYTHONUNBUFFERED=1
+# Set the working directory in the container
+WORKDIR /app
 
 # Install Poetry
 RUN pip install poetry
 
-# Set the working directory in the container
-WORKDIR /app
+# Copy the pyproject.toml and poetry.lock files to the working directory
+COPY pyproject.toml poetry.lock ./
 
-# Copy the pyproject.toml file
-COPY pyproject.toml ./
+# Install the dependencies without creating a virtual environment
+RUN poetry config virtualenvs.create false \
+    && poetry install --no-root --no-interaction --no-ansi
 
-# Create a non-root user with an explicit UID and adds permission to access the /app folder
-RUN adduser -u 5678 --disabled-password --gecos "" appuser && chown -R appuser /app
-
-# Switch to the non-root user
-USER appuser
-
-# Install dependencies
-RUN poetry install --no-root --no-dev
-
-# Copy the application code
+# Copy the rest of the application code into the container
 COPY . .
 
-# Run the application with gunicorn
-CMD ["poetry", "run", "gunicorn", "--bind", "0.0.0.0:5000", "app.main:app"]
+# Expose the port that the Flask app runs on
+EXPOSE 8080
 
+# Define environment variables
+ENV FLASK_APP=app/main.py
+ENV FLASK_ENV=production
+
+# Run the application with Gunicorn
+CMD ["poetry", "run", "gunicorn", "--bind", "0.0.0.0:8080", "app.main:app"]

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,14 +1,14 @@
-version: '3.4'
+version: '3.8'
 
 services:
-  yourip:
-    image: yourip
-    build:
-      context: .
-      dockerfile: ./Dockerfile
-    command: ["sh", "-c", "pip install debugpy -t /tmp && python /tmp/debugpy --wait-for-client --listen 0.0.0.0:5678 -m flask run --no-debugger --no-reload --host 0.0.0.0 --port 5000"]
+  web:
+    image: yourip:latest
+    container_name: yourip_debug
     ports:
-      - 5000:5000
-      - 5678:5678
+      - "8080:8080"
     environment:
-      - FLASK_APP=app/main.py
+      FLASK_ENV: development
+      FLASK_APP: app/main.py
+    command: poetry run flask run --host=0.0.0.0 --port=8080
+    volumes:
+      - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
-version: '3.4'
+version: '3.8'
 
 services:
-  yourip:
-    image: yourip
-    build:
-      context: .
-      dockerfile: ./Dockerfile
+  web:
+    image: yourip:latest
+    container_name: yourip
     ports:
-      - 5000:5000
+      - "8080:8080"
+    environment:
+      FLASK_ENV: production
+      FLASK_APP: app/main.py

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -7,11 +7,12 @@ When contributing to this repository, please first discuss the change you wish t
 ## Table of Contents
 
 1. Getting Started
-2. Testing Locally
-3. Running Tests
-4. Code Coverage
-5. Continuous Integration
-6. Submitting Changes
+1. Testing Locally
+1. Running Tests
+1. Code Coverage
+1. Continuous Integration
+1. Using Docker & Compose
+1. Submitting Changes
 
 ## Getting Started
 
@@ -95,6 +96,45 @@ We've set up GitHub Actions for Continuous Integration (CI) to automatically run
 1. Push your changes to your fork.
 2. Create a pull request to the main repository.
 3. The CI will automatically run and display results on the pull request page.
+
+## Using Docker & Compose
+
+### Building the Docker Image
+
+To build the Docker image and tag it as yourip:
+
+1. Ensure you are in the root directory of the repository where the Dockerfile is located.
+1. Build the Docker image:
+
+```bash
+docker build -t yourip:latest .
+```
+
+This command builds the Docker image using the Dockerfile in the current directory and tags it as yourip:latest.
+
+### Using docker-compose.yml
+
+To run the application using the production settings:
+
+#### Run the Docker Compose command:
+
+```bash
+docker compose up -d
+```
+
+This command uses docker-compose.yml to start the container in detached mode.
+
+### Using docker-compose.debug.yml
+
+To run the application in development mode with debugging:
+
+#### Run the Docker Compose command:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.debug.yml up -d
+```
+
+This command uses both docker-compose.yml and docker-compose.debug.yml to start the container in detached mode with development settings.
 
 ## Submitting Changes
 


### PR DESCRIPTION
build(Dockerfile): update Dockerfile to install dependencies without creating a virtual environment and expose port 8080 for Flask app

build(docker-compose.debug.yml): update docker-compose.debug.yml to use port 8080 and set FLASK_ENV to development

build(docker-compose.yml): update docker-compose.yml to use port 8080 and set FLASK_ENV to production

docs(CONTRIBUTING.md): add section on using Docker & Compose for building and running the application The changes were made to improve the Docker setup by installing dependencies without creating a virtual environment, exposing port 8080 for the Flask app, and updating the docker-compose files to reflect the changes in port and environment variables. Additionally, a new section was added to the CONTRIBUTING.md file to guide users on using Docker and Compose for building and running the application.
