### PR TITLE
Add GitHub Actions workflow to publish Dockerfile image to GHCR

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,38 @@
+name: Publish Docker Image to GHCR
+
+on:
+  push:
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/publish-docker-image.yml'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/yourip:latest
+
+      - name: Logout from GHCR
+        run: docker logout ghcr.io

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v3

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v3


### PR DESCRIPTION
feat(publish-docker-image.yml): add GitHub Actions workflow to build and publish Docker image to GHCR

The new GitHub Actions workflow file `publish-docker-image.yml` has been added to the `.github/workflows` directory. This workflow is triggered on a push event that modifies the `Dockerfile` or the workflow file itself. It sets up the necessary actions to build and publish a Docker image to GitHub Container Registry (GHCR). The workflow includes steps to checkout the repository, set up QEMU, set up Docker Buildx, login to GHCR using Docker login action, build and push the Docker image, and finally logout from GHCR. This workflow enhances the project's automation by enabling seamless building and publishing of Docker images to GHCR.
