### PR TITLE
fix(create-new-release.yml): update client-payload to use github.ref_…

### DIFF
--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -49,4 +49,4 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         repository: ${{ github.repository }}
         event-type: publish-docker-image
-        client-payload: '{"tag": "${{ github.ref }}"}'
+        client-payload: '{"tag": "${{ github.ref_name }}"}'

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -35,30 +35,34 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
+      - name: Set TAG variable
         run: |
-          TAG="${{ github.event.client_payload.tag || github.event.inputs.tag }}"
-          if [ -z "${TAG}" ]; then
-            echo "Error: TAG is not defined. Please ensure that the tag is set in your environment variables or input parameters."
-            exit 1
-          fi
-            echo "Tag is not defined"
+          if [ "${{ github.event_name }}" == "repository_dispatch" ]; then
+            TAG="${{ github.event.client_payload.tag }}"
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          elif [ "${{ github.event_name }}" == "push" ]; then
+            if [[ "${{ github.event.head_commit.message }}" == *"Update publish-docker-image.yml"* ]]; then
+              TAG="test"
+            else
+              TAG="nightly"
+            fi
+          else
+            echo "Unsupported event: ${{ github.event_name }}"
             exit 1
           fi
 
-          if [ "${TAG}" = "nightly" ]; then
-            docker buildx build \
-              --tag ghcr.io/${{ github.repository_owner }}/yourip:nightly \
-              --push .
-          elif [ "${TAG}" = "test" ]; then
-            docker buildx build \
-              --tag ghcr.io/${{ github.repository_owner }}/yourip:test \
-              --push .
-          else
-            docker buildx build \
-              --tag ghcr.io/${{ github.repository_owner }}/yourip:${TAG} \
-              --tag ghcr.io/${{ github.repository_owner }}/yourip:latest \
-              --push .
+          if [ -z "$TAG" ]; then
+            echo "TAG is not defined. Please ensure that the tag is set in your environment variables or input parameters."
+            exit 1
+          fi
+          echo "TAG=$TAG" >> $GITHUB_ENV
+
+      - name: Build and push Docker image
+        run: |
+          docker buildx build \
+            --tag ghcr.io/${{ github.repository_owner }}/yourip:${TAG} \
+            --push .
 
       - name: Logout from GHCR
         run: docker logout ghcr.io

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -39,6 +39,9 @@ jobs:
         run: |
           TAG="${{ github.event.client_payload.tag || github.event.inputs.tag }}"
           if [ -z "${TAG}" ]; then
+            echo "Error: TAG is not defined. Please ensure that the tag is set in your environment variables or input parameters."
+            exit 1
+          fi
             echo "Tag is not defined"
             exit 1
           fi

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -4,11 +4,14 @@ on:
   push:
     paths:
       - 'Dockerfile'
-      - '.github/workflows/publish-docker-image.yml'
-  workflow_dispatch:
-  # Triggered by a repository_dispatch event to allow external systems to initiate the workflow
   repository_dispatch:
     types: [publish-docker-image]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Docker image tag'
+        required: true
+        default: 'nightly'
 
 jobs:
   build-and-publish:
@@ -31,22 +34,24 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image with version tag
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/yourip:${{ github.event.client_payload.tag }}
-            ghcr.io/${{ github.repository_owner }}/yourip:latest
+      - name: Build and push Docker image
+        run: |
+          TAG="${{ github.event.client_payload.tag || github.event.inputs.tag }}"
+          if [ -z "${TAG}" ]; then
+            echo "Tag is not defined"
+            exit 1
+          fi
 
-      - name: Build and push Docker image with nightly tag
-        if: github.event.client_payload.tag == 'nightly'
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: true
-          tags: ghcr.io/${{ github.repository_owner }}/yourip:nightly
+          if [ "${TAG}" = "nightly" ]; then
+            docker buildx build \
+              --tag ghcr.io/${{ github.repository_owner }}/yourip:nightly \
+              --push .
+          else
+            docker buildx build \
+              --tag ghcr.io/${{ github.repository_owner }}/yourip:${TAG} \
+              --tag ghcr.io/${{ github.repository_owner }}/yourip:latest \
+              --push .
+          fi
 
       - name: Logout from GHCR
         run: docker logout ghcr.io

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'Dockerfile'
+      - '.github/workflows/publish-docker-image.yml'
   repository_dispatch:
     types: [publish-docker-image]
   workflow_dispatch:
@@ -46,12 +47,15 @@ jobs:
             docker buildx build \
               --tag ghcr.io/${{ github.repository_owner }}/yourip:nightly \
               --push .
+          elif [ "${TAG}" = "test" ]; then
+            docker buildx build \
+              --tag ghcr.io/${{ github.repository_owner }}/yourip:test \
+              --push .
           else
             docker buildx build \
               --tag ghcr.io/${{ github.repository_owner }}/yourip:${TAG} \
               --tag ghcr.io/${{ github.repository_owner }}/yourip:latest \
               --push .
-          fi
 
       - name: Logout from GHCR
         run: docker logout ghcr.io


### PR DESCRIPTION
…name instead of github.ref to correctly reference the branch name

feat(publish-docker-image.yml): add support for specifying a custom tag when triggering the workflow manually The client-payload in create-new-release.yml is updated to use github.ref_name instead of github.ref to ensure the correct branch name is used. In publish-docker-image.yml, support is added for specifying a custom tag when manually triggering the workflow using workflow_dispatch. This allows users to provide a specific tag for the Docker image build and push process.
