### PR TITLE
ci(workflows): disable Fly.io deployment workflows in preparation for migration to Vercel

### DIFF
--- a/.github/workflows/deploy-flyio-app.yml
+++ b/.github/workflows/deploy-flyio-app.yml
@@ -1,9 +1,10 @@
 name: Prod Deploy
 
 on:
-  release:
-    types: [published]
-  workflow_dispatch:
+# Disabled for move to vercel
+#  pull_request:
+#    types: [closed]
+workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-flyio-pr.yml
+++ b/.github/workflows/deploy-flyio-pr.yml
@@ -1,7 +1,8 @@
 name: PR Deploy
 on:
-  pull_request:
-    types: [closed]
+# Disabled for move to vercel
+#  pull_request:
+#    types: [closed]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
The Fly.io deployment workflows for both production and pull requests are disabled. This change is made to facilitate the migration of the deployment process to Vercel. By commenting out the relevant sections, the workflows are effectively paused without being deleted, allowing for potential reactivation if needed.
